### PR TITLE
Accept APPLE_HEALTH resting HR source on profile save

### DIFF
--- a/src/routes/user_profile_routes.py
+++ b/src/routes/user_profile_routes.py
@@ -57,6 +57,7 @@ from src.services.training_plan.recalculate_hr_zones_service import (
 from src.db.models.plans import Plan
 from src.utils.user_profile_age_group import age_group_band_from_birth_year
 from src.utils.hr_zone_constants import manual_max_hr_bpm_bounds
+from src.utils.resting_hr_source import resolve_resting_hr_source_for_save
 
 user_profile_bp = Blueprint("user_profile", __name__, url_prefix="/api")
 
@@ -85,6 +86,12 @@ def submit_user_profile():
 
     data = request.get_json(silent=True) or {}
     current_app.logger.debug(f"[submit_user_profile] Received data: {data}")
+
+    # Mobile clients may send snake_case HR fields.
+    if "resting_hr" in data and "restingHr" not in data:
+        data["restingHr"] = data["resting_hr"]
+    if "resting_hr_source" in data and "restingHrSource" not in data:
+        data["restingHrSource"] = data["resting_hr_source"]
 
     # No mapping needed - age_group is now a string column that stores user-friendly ranges like "30-39"
 
@@ -138,6 +145,12 @@ def submit_user_profile():
         # Map restingHr to resting_hr (camelCase -> snake_case)
         if "restingHr" in user_dict:
             user_dict["resting_hr"] = user_dict.pop("restingHr")
+
+        requested_resting_hr_source = user_dict.pop("restingHrSource", None)
+        if requested_resting_hr_source is None:
+            requested_resting_hr_source = user_dict.pop("resting_hr_source", None)
+        elif "resting_hr_source" in user_dict:
+            user_dict.pop("resting_hr_source", None)
 
         if "maxHrActive" in user_dict:
             user_dict["max_hr_active"] = user_dict.pop("maxHrActive")
@@ -218,11 +231,15 @@ def submit_user_profile():
 
             new_effective = HRMaxResolutionService.get_effective_max_hr(merged)
 
-            # Explicit resting HR save sets USER; APPLE_HEALTH may be set in a future import flow.
-            if new_resting_hr is not None and new_resting_hr != old_resting_hr:
+            resolved_source = resolve_resting_hr_source_for_save(
+                raw_body=raw_body,
+                requested_source=requested_resting_hr_source,
+                new_resting_hr=new_resting_hr,
+            )
+            if resolved_source is not None:
                 from datetime import datetime
 
-                merged["resting_hr_source"] = "USER"
+                merged["resting_hr_source"] = resolved_source
                 merged["resting_hr_updated_at"] = datetime.now()
 
             merged.pop("max_hr", None)

--- a/src/schemas/user_profile_schema.py
+++ b/src/schemas/user_profile_schema.py
@@ -39,6 +39,10 @@ class UserProfileSchema(BaseModel):
     restingHr: Optional[int] = Field(
         None, ge=35, le=110, description="Resting heart rate in bpm"
     )  # Resting heart rate in bpm
+    restingHrSource: Optional[Literal["USER", "APPLE_HEALTH"]] = Field(
+        None,
+        description="How resting HR was obtained; only honored with an explicit restingHr save",
+    )
 
     @field_validator("birthYear")
     @classmethod

--- a/src/utils/hr_zone_constants.py
+++ b/src/utils/hr_zone_constants.py
@@ -378,3 +378,6 @@ RESTING_HR_ESTIMATION = {
     # Default fallback if age cannot be determined
     "DEFAULT_RESTING_HR": 70,
 }
+
+# Writable resting HR sources (profile save / onboarding). ESTIMATED is legacy read-only.
+ALLOWED_RESTING_HR_WRITE_SOURCES = frozenset({"USER", "APPLE_HEALTH"})

--- a/src/utils/resting_hr_source.py
+++ b/src/utils/resting_hr_source.py
@@ -1,0 +1,47 @@
+"""Resting HR source resolution for profile save."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from src.utils.hr_zone_constants import ALLOWED_RESTING_HR_WRITE_SOURCES
+
+
+def _normalize_source(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().upper()
+    return normalized or None
+
+
+def requested_resting_hr_source(raw_body: dict[str, Any]) -> Optional[str]:
+    """Read resting HR source from request body (camelCase or snake_case)."""
+    for key in ("restingHrSource", "resting_hr_source"):
+        if key in raw_body:
+            return _normalize_source(raw_body.get(key))
+    return None
+
+
+def resolve_resting_hr_source_for_save(
+    *,
+    raw_body: dict[str, Any],
+    requested_source: Optional[str],
+    new_resting_hr: Optional[int],
+) -> Optional[str]:
+    """
+    Resolve source when this request explicitly saves resting HR.
+
+    Returns USER, APPLE_HEALTH, or None when resting HR is not being saved.
+    Invalid or unsupported values default to USER (never ESTIMATED).
+    APPLE_HEALTH is only returned when explicitly requested with a resting HR value.
+    """
+    explicit_resting_hr = "restingHr" in raw_body or "resting_hr" in raw_body
+    if not explicit_resting_hr or new_resting_hr is None:
+        return None
+
+    source = requested_source or requested_resting_hr_source(raw_body)
+    if source == "APPLE_HEALTH" and source in ALLOWED_RESTING_HR_WRITE_SOURCES:
+        return "APPLE_HEALTH"
+    return "USER"

--- a/tests/services/heart_rate/test_phase0_smoke_resting_hr.py
+++ b/tests/services/heart_rate/test_phase0_smoke_resting_hr.py
@@ -1,0 +1,126 @@
+"""Phase 0 smoke checks: pct_max fallback, no silent resting HR writes, manual save + recalc."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from src.app import app
+from src.db.dao.user_profile_dao import get_user_profile, save_user_profile
+from src.services.heart_rate.heart_rate_orchestration_service import (
+    HeartRateZoneOrchestrationService,
+)
+from src.smartcoach_mobile_coach.runner_profile.hr_builder import compute_hr_zones
+
+DEFAULT_USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+DEFAULT_USER_ID_STR = str(DEFAULT_USER_ID)
+
+client = app.test_client()
+HEADERS = {
+    "Origin": "http://localhost:5173",
+    "Authorization": "Bearer fake-token",
+}
+
+
+@pytest.fixture(autouse=True)
+def stub_auth_user_id(monkeypatch):
+    monkeypatch.setattr(
+        "src.utils.auth0_jwt.resolve_user_id_from_auth_provider",
+        lambda *args, **kwargs: DEFAULT_USER_ID,
+    )
+
+
+def _profile(**overrides):
+    profile = {
+        "user_id": DEFAULT_USER_ID_STR,
+        "height_feet": 5,
+        "height_inches": 10,
+        "max_hr_manual": 180,
+        "max_hr_active": "manual",
+        "age_group": "25-34",
+        "resting_hr": None,
+        "resting_hr_source": None,
+    }
+    profile.update(overrides)
+    return profile
+
+
+def _onboarding_base_payload(**overrides):
+    payload = {
+        "user_id": DEFAULT_USER_ID_STR,
+        "height": {"feet": 5, "inches": 10},
+        "weight": 165,
+        "ageGroup": "25-34",
+        "max_hr_manual": 180,
+        "max_hr_active": "manual",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestPhase0SmokePctMaxFallback:
+    def test_zones_compute_via_pct_max_without_resting_hr(self, test_db_session):
+        save_user_profile(test_db_session, _profile())
+
+        zones = compute_hr_zones(test_db_session, DEFAULT_USER_ID_STR)
+        assert zones is not None
+        assert zones.method == "pct_max"
+        assert zones.resting_hr_used is None
+        assert zones.hrmax_used == 180
+        assert "z2" in zones.zones
+
+    def test_calculate_zones_e2e_leaves_profile_resting_hr_null(self, test_db_session):
+        save_user_profile(test_db_session, _profile())
+
+        with patch(
+            "src.smartcoach_mobile_coach.runner_profile.service.compute_pace_zones_from_activities",
+            return_value=None,
+        ):
+            result = HeartRateZoneOrchestrationService.calculate_zones_for_user(
+                test_db_session, DEFAULT_USER_ID_STR
+            )
+
+        assert result["success"] is True
+        assert result.get("zones")
+        assert result.get("resting_hr") is None
+
+        profile = get_user_profile(test_db_session, DEFAULT_USER_ID_STR)
+        assert profile["resting_hr"] is None
+        assert profile.get("resting_hr_source") is None
+
+
+class TestPhase0SmokeOnboardingManualSave:
+    def test_manual_resting_hr_save_sets_user_source(self, test_db_session):
+        save_user_profile(test_db_session, _profile())
+
+        response = client.post(
+            "/api/onboarding",
+            json=_onboarding_base_payload(restingHr=55),
+            headers=HEADERS,
+        )
+        assert response.status_code == 200
+
+        profile = get_user_profile(test_db_session, DEFAULT_USER_ID_STR)
+        assert profile["resting_hr"] == 55
+        assert profile["resting_hr_source"] == "USER"
+        assert profile["resting_hr_updated_at"] is not None
+
+    def test_resting_hr_change_triggers_hr_zone_recalc(self, test_db_session):
+        save_user_profile(test_db_session, _profile())
+
+        with patch(
+            "src.services.training_plan.recalculate_hr_zones_service.recalculate_hr_zones_for_user",
+            return_value={},
+        ) as recalc_mock:
+            response = client.post(
+                "/api/onboarding",
+                json=_onboarding_base_payload(restingHr=58),
+                headers=HEADERS,
+            )
+
+        assert response.status_code == 200
+        recalc_mock.assert_called_once()
+        call_args = recalc_mock.call_args[0]
+        assert str(call_args[1]) == DEFAULT_USER_ID_STR

--- a/tests/services/heart_rate/test_resting_hr_source_on_save.py
+++ b/tests/services/heart_rate/test_resting_hr_source_on_save.py
@@ -1,0 +1,187 @@
+"""Tests for resting HR source on onboarding/profile save (Phase 1 backend)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from src.app import app
+from src.db.dao.user_profile_dao import get_user_profile, save_user_profile
+from src.utils.resting_hr_source import resolve_resting_hr_source_for_save
+
+DEFAULT_USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+DEFAULT_USER_ID_STR = str(DEFAULT_USER_ID)
+
+client = app.test_client()
+HEADERS = {
+    "Origin": "http://localhost:5173",
+    "Authorization": "Bearer fake-token",
+}
+
+
+@pytest.fixture(autouse=True)
+def stub_auth_user_id(monkeypatch):
+    monkeypatch.setattr(
+        "src.utils.auth0_jwt.resolve_user_id_from_auth_provider",
+        lambda *args, **kwargs: DEFAULT_USER_ID,
+    )
+
+
+def _profile(**overrides):
+    profile = {
+        "user_id": DEFAULT_USER_ID_STR,
+        "height_feet": 5,
+        "height_inches": 10,
+        "max_hr_manual": 180,
+        "max_hr_active": "manual",
+        "age_group": "25-34",
+        "resting_hr": None,
+        "resting_hr_source": None,
+    }
+    profile.update(overrides)
+    return profile
+
+
+def _onboarding_base_payload(**overrides):
+    payload = {
+        "user_id": DEFAULT_USER_ID_STR,
+        "height": {"feet": 5, "inches": 10},
+        "weight": 165,
+        "ageGroup": "25-34",
+        "max_hr_manual": 180,
+        "max_hr_active": "manual",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestResolveRestingHrSourceHelper:
+    def test_apple_health_requires_explicit_resting_hr(self):
+        assert (
+            resolve_resting_hr_source_for_save(
+                raw_body={"restingHr": 55, "restingHrSource": "APPLE_HEALTH"},
+                requested_source="APPLE_HEALTH",
+                new_resting_hr=55,
+            )
+            == "APPLE_HEALTH"
+        )
+        assert (
+            resolve_resting_hr_source_for_save(
+                raw_body={"restingHrSource": "APPLE_HEALTH"},
+                requested_source="APPLE_HEALTH",
+                new_resting_hr=55,
+            )
+            is None
+        )
+
+    def test_invalid_source_defaults_to_user(self):
+        assert (
+            resolve_resting_hr_source_for_save(
+                raw_body={"restingHr": 55, "restingHrSource": "ESTIMATED"},
+                requested_source="ESTIMATED",
+                new_resting_hr=55,
+            )
+            == "USER"
+        )
+
+
+class TestRestingHrSourceOnboardingSave:
+    def test_apple_health_source_persists(self, test_db_session):
+        save_user_profile(test_db_session, _profile())
+
+        response = client.post(
+            "/api/onboarding",
+            json=_onboarding_base_payload(restingHr=54, restingHrSource="APPLE_HEALTH"),
+            headers=HEADERS,
+        )
+        assert response.status_code == 200
+
+        profile = get_user_profile(test_db_session, DEFAULT_USER_ID_STR)
+        assert profile["resting_hr"] == 54
+        assert profile["resting_hr_source"] == "APPLE_HEALTH"
+
+    def test_apple_health_accepts_snake_case_fields(self, test_db_session):
+        save_user_profile(test_db_session, _profile())
+
+        response = client.post(
+            "/api/onboarding",
+            json=_onboarding_base_payload(
+                resting_hr=53, resting_hr_source="APPLE_HEALTH"
+            ),
+            headers=HEADERS,
+        )
+        assert response.status_code == 200
+
+        profile = get_user_profile(test_db_session, DEFAULT_USER_ID_STR)
+        assert profile["resting_hr"] == 53
+        assert profile["resting_hr_source"] == "APPLE_HEALTH"
+
+    def test_manual_save_sets_user_source(self, test_db_session):
+        save_user_profile(test_db_session, _profile())
+
+        response = client.post(
+            "/api/onboarding",
+            json=_onboarding_base_payload(restingHr=55),
+            headers=HEADERS,
+        )
+        assert response.status_code == 200
+
+        profile = get_user_profile(test_db_session, DEFAULT_USER_ID_STR)
+        assert profile["resting_hr"] == 55
+        assert profile["resting_hr_source"] == "USER"
+
+    def test_manual_save_after_apple_health_overrides_source(self, test_db_session):
+        save_user_profile(
+            test_db_session,
+            _profile(
+                resting_hr=55,
+                resting_hr_source="APPLE_HEALTH",
+                resting_hr_updated_at=datetime.now(),
+            ),
+        )
+
+        response = client.post(
+            "/api/onboarding",
+            json=_onboarding_base_payload(restingHr=55),
+            headers=HEADERS,
+        )
+        assert response.status_code == 200
+
+        profile = get_user_profile(test_db_session, DEFAULT_USER_ID_STR)
+        assert profile["resting_hr"] == 55
+        assert profile["resting_hr_source"] == "USER"
+
+    def test_invalid_source_rejected_and_not_persisted(self, test_db_session):
+        save_user_profile(test_db_session, _profile())
+
+        response = client.post(
+            "/api/onboarding",
+            json=_onboarding_base_payload(restingHr=55, restingHrSource="ESTIMATED"),
+            headers=HEADERS,
+        )
+        assert response.status_code == 400
+
+        profile = get_user_profile(test_db_session, DEFAULT_USER_ID_STR)
+        assert profile["resting_hr"] is None
+        assert profile.get("resting_hr_source") is None
+
+    def test_resting_hr_change_triggers_recalc(self, test_db_session):
+        save_user_profile(test_db_session, _profile())
+
+        with patch(
+            "src.services.training_plan.recalculate_hr_zones_service.recalculate_hr_zones_for_user",
+            return_value={},
+        ) as recalc_mock:
+            response = client.post(
+                "/api/onboarding",
+                json=_onboarding_base_payload(
+                    restingHr=58, restingHrSource="APPLE_HEALTH"
+                ),
+                headers=HEADERS,
+            )
+
+        assert response.status_code == 200
+        recalc_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- Extend POST /api/onboarding to accept restingHrSource / resting_hr_source when paired with an explicit resting HR save.
- Manual saves default to USER; APPLE_HEALTH is honored only on confirmed import saves; ESTIMATED is rejected at validation.
- Accept snake_case resting_hr fields from mobile clients.
- Add Phase 0 smoke tests and Phase 1 source-on-save tests (18 total in heart_rate suite).

## Test plan
- [x] pytest tests/services/heart_rate/test_resting_hr_source_on_save.py
- [x] pytest tests/services/heart_rate/test_phase0_smoke_resting_hr.py
- [x] pytest tests/services/heart_rate/test_resting_hr_no_estimation.py
- [ ] Merge to dev, then staging/prod per usual deploy flow
- [ ] Mobile Phase 1 can POST resting_hr + resting_hr_source: APPLE_HEALTH after merge

Made with [Cursor](https://cursor.com)