### PR TITLE
Refactor Tempo segment extraction onto shared qualified segment core

### DIFF
--- a/src/smartcoach_mobile_coach/execution_analytics/qualified_segment.py
+++ b/src/smartcoach_mobile_coach/execution_analytics/qualified_segment.py
@@ -1,0 +1,231 @@
+"""
+HR-qualified split segment mechanics shared by Insights pace systems (Tempo/Z3, etc.).
+
+Zone-specific split classification and source labels live in per-system wrappers
+(e.g. ``tempo_segment``). This module holds only generic selection, weighting,
+confidence, and aggregation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Literal, Sequence
+
+SegmentConfidence = Literal["high", "medium", "low"]
+
+
+@dataclass(frozen=True)
+class SplitRow:
+    split_index: int
+    avg_hr: float | None
+    pace_min_per_mi: float | None
+    distance_mi: float | None
+
+
+@dataclass(frozen=True)
+class QualifyingSplit:
+    split_index: int
+    pace_min_per_mi: float
+    distance_mi: float
+    avg_hr_bpm: float
+    tier: str
+
+
+@dataclass(frozen=True)
+class SourceConfidencePolicy:
+    """Maps qualifying tier labels to pace source strings for chart eligibility."""
+
+    primary_tier: str
+    primary_source: str
+    fallback_source: str
+
+
+@dataclass(frozen=True)
+class SegmentAggregateResult:
+    segment_pace_min_per_mi: float | None
+    segment_avg_hr_bpm: float | None
+    segment_pace_source: str | None
+    segment_split_count: int
+    segment_confidence: SegmentConfidence | None
+
+
+def eligible_split_indices(
+    split_indices: list[int],
+    *,
+    min_splits_for_warmup_trim: int,
+) -> set[int]:
+    if len(split_indices) < min_splits_for_warmup_trim:
+        return set(split_indices)
+    ordered = sorted(split_indices)
+    return set(ordered[1:-1])
+
+
+def distance_weighted_pace_min_per_mi(
+    qualifying: Sequence[QualifyingSplit],
+) -> float | None:
+    if not qualifying:
+        return None
+    num = 0.0
+    den = 0.0
+    for split in qualifying:
+        num += split.pace_min_per_mi * split.distance_mi
+        den += split.distance_mi
+    if den <= 0:
+        return None
+    return round(num / den, 4)
+
+
+def distance_weighted_avg_hr_bpm(
+    qualifying: Sequence[QualifyingSplit],
+) -> float | None:
+    if not qualifying:
+        return None
+    num = 0.0
+    den = 0.0
+    for split in qualifying:
+        num += split.avg_hr_bpm * split.distance_mi
+        den += split.distance_mi
+    if den <= 0:
+        return None
+    return round(num / den, 2)
+
+
+def qualifying_miles(qualifying: Sequence[QualifyingSplit]) -> float:
+    return sum(split.distance_mi for split in qualifying)
+
+
+def has_strong_qualifying_volume(
+    qualifying: Sequence[QualifyingSplit],
+    *,
+    min_splits: int,
+    min_miles: float,
+) -> bool:
+    return len(qualifying) >= min_splits and qualifying_miles(qualifying) >= min_miles
+
+
+def resolve_source_and_confidence(
+    qualifying: Sequence[QualifyingSplit],
+    policy: SourceConfidencePolicy,
+    *,
+    min_splits: int,
+    min_miles: float,
+) -> tuple[str, SegmentConfidence]:
+    has_primary = any(split.tier == policy.primary_tier for split in qualifying)
+    strong = has_strong_qualifying_volume(
+        qualifying, min_splits=min_splits, min_miles=min_miles
+    )
+    if has_primary:
+        return (
+            policy.primary_source,
+            "high" if strong else "medium",
+        )
+    return (
+        policy.fallback_source,
+        "medium" if strong else "low",
+    )
+
+
+def select_qualifying_splits(
+    splits: Sequence[SplitRow],
+    *,
+    classify_split_hr: Callable[[float], str | None],
+    primary_tier: str,
+    quality_tier: str,
+    min_splits_for_warmup_trim: int,
+) -> list[QualifyingSplit]:
+    if not splits:
+        return []
+
+    eligible = eligible_split_indices(
+        [s.split_index for s in splits],
+        min_splits_for_warmup_trim=min_splits_for_warmup_trim,
+    )
+    tiered: list[tuple[str, SplitRow]] = []
+
+    for row in splits:
+        if row.split_index not in eligible:
+            continue
+        if row.avg_hr is None or row.pace_min_per_mi is None or row.distance_mi is None:
+            continue
+        if row.distance_mi <= 0 or row.pace_min_per_mi <= 0:
+            continue
+        tier = classify_split_hr(float(row.avg_hr))
+        if tier is not None:
+            tiered.append((tier, row))
+
+    primary = [
+        QualifyingSplit(
+            split_index=row.split_index,
+            pace_min_per_mi=float(row.pace_min_per_mi),
+            distance_mi=float(row.distance_mi),
+            avg_hr_bpm=float(row.avg_hr),
+            tier=primary_tier,
+        )
+        for tier, row in tiered
+        if tier == primary_tier
+    ]
+    if primary:
+        return primary
+
+    return [
+        QualifyingSplit(
+            split_index=row.split_index,
+            pace_min_per_mi=float(row.pace_min_per_mi),
+            distance_mi=float(row.distance_mi),
+            avg_hr_bpm=float(row.avg_hr),
+            tier=quality_tier,
+        )
+        for tier, row in tiered
+        if tier == quality_tier
+    ]
+
+
+def aggregate_qualifying_splits(
+    qualifying: Sequence[QualifyingSplit],
+    policy: SourceConfidencePolicy,
+    *,
+    min_splits_strong: int,
+    min_miles_strong: float,
+) -> SegmentAggregateResult:
+    pace = distance_weighted_pace_min_per_mi(qualifying)
+    avg_hr = distance_weighted_avg_hr_bpm(qualifying)
+    if pace is None or avg_hr is None:
+        return SegmentAggregateResult(
+            segment_pace_min_per_mi=None,
+            segment_avg_hr_bpm=None,
+            segment_pace_source=None,
+            segment_split_count=0,
+            segment_confidence=None,
+        )
+
+    source, confidence = resolve_source_and_confidence(
+        qualifying,
+        policy,
+        min_splits=min_splits_strong,
+        min_miles=min_miles_strong,
+    )
+
+    return SegmentAggregateResult(
+        segment_pace_min_per_mi=pace,
+        segment_avg_hr_bpm=avg_hr,
+        segment_pace_source=source,
+        segment_split_count=len(qualifying),
+        segment_confidence=confidence,
+    )
+
+
+def combine_weekly_qualifying_splits(
+    per_run_qualifying: Sequence[Sequence[QualifyingSplit]],
+    policy: SourceConfidencePolicy,
+    *,
+    min_splits_strong: int,
+    min_miles_strong: float,
+) -> SegmentAggregateResult:
+    """Distance-weighted rollup across all qualifying splits in the week."""
+    combined = [split for run in per_run_qualifying for split in run]
+    return aggregate_qualifying_splits(
+        combined,
+        policy,
+        min_splits_strong=min_splits_strong,
+        min_miles_strong=min_miles_strong,
+    )

--- a/src/smartcoach_mobile_coach/execution_analytics/tempo_segment.py
+++ b/src/smartcoach_mobile_coach/execution_analytics/tempo_segment.py
@@ -3,13 +3,26 @@ Executed Tempo/Z3 pace from split/lap HR qualification (Tier 2 SSOT).
 
 Selects Tempo-quality splits by HR zone (never by goal pace corridor), then
 distance-weighted aggregation. Full-activity average pace is diagnostic only.
+
+Generic mechanics live in ``qualified_segment``; this module is the Tempo public API.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, cast
 
+from src.smartcoach_mobile_coach.execution_analytics.qualified_segment import (
+    QualifyingSplit,
+    SegmentAggregateResult,
+    SourceConfidencePolicy,
+    SplitRow,
+    aggregate_qualifying_splits as _aggregate_qualifying_splits,
+    combine_weekly_qualifying_splits,
+    distance_weighted_avg_hr_bpm as _distance_weighted_avg_hr_bpm,
+    distance_weighted_pace_min_per_mi as _distance_weighted_pace_min_per_mi,
+    select_qualifying_splits,
+)
 from src.smartcoach_mobile_coach.execution_analytics.thresholds import (
     MIN_QUALIFYING_MILES_STRONG_EVIDENCE,
     MIN_SPLITS_STRONG_EVIDENCE,
@@ -25,7 +38,13 @@ TempoSegmentPaceSource = Literal[
 TempoSegmentConfidence = Literal["high", "medium", "low"]
 QualificationTier = Literal["z3", "quality"]
 
-_MIN_SPLITS_FOR_WARMUP_TRIM = TEMPO_RUN_MIN_SPLITS_WITH_HR
+_TEMPO_POLICY = SourceConfidencePolicy(
+    primary_tier="z3",
+    primary_source="splits_hr_z3",
+    fallback_source="splits_hr_quality",
+)
+_TEMPO_PRIMARY_TIER = "z3"
+_TEMPO_QUALITY_TIER = "quality"
 
 
 @dataclass(frozen=True)
@@ -66,13 +85,6 @@ class TempoSegmentPaceResult:
         return self.tempo_segment_confidence in ("high", "medium")
 
 
-def _eligible_split_indices(split_indices: list[int]) -> set[int]:
-    if len(split_indices) < _MIN_SPLITS_FOR_WARMUP_TRIM:
-        return set(split_indices)
-    ordered = sorted(split_indices)
-    return set(ordered[1:-1])
-
-
 def _classify_split_hr(
     avg_hr: float,
     zones: TempoHrZoneBounds,
@@ -86,134 +98,98 @@ def _classify_split_hr(
     return None
 
 
+def _split_rows_from_tempo(splits: list[TempoSplitRow]) -> list[SplitRow]:
+    return [
+        SplitRow(
+            split_index=row.split_index,
+            avg_hr=row.avg_hr,
+            pace_min_per_mi=row.pace_min_per_mi,
+            distance_mi=row.distance_mi,
+        )
+        for row in splits
+    ]
+
+
+def _qualifying_from_core(splits: list[QualifyingSplit]) -> list[QualifyingTempoSplit]:
+    return [
+        QualifyingTempoSplit(
+            split_index=split.split_index,
+            pace_min_per_mi=split.pace_min_per_mi,
+            distance_mi=split.distance_mi,
+            avg_hr_bpm=split.avg_hr_bpm,
+            tier=cast(QualificationTier, split.tier),
+        )
+        for split in splits
+    ]
+
+
+def _qualifying_to_core(
+    qualifying: list[QualifyingTempoSplit],
+) -> list[QualifyingSplit]:
+    return [
+        QualifyingSplit(
+            split_index=split.split_index,
+            pace_min_per_mi=split.pace_min_per_mi,
+            distance_mi=split.distance_mi,
+            avg_hr_bpm=split.avg_hr_bpm,
+            tier=split.tier,
+        )
+        for split in qualifying
+    ]
+
+
+def _tempo_result_from_aggregate(agg: SegmentAggregateResult) -> TempoSegmentPaceResult:
+    source = cast(TempoSegmentPaceSource | None, agg.segment_pace_source)
+    confidence = cast(TempoSegmentConfidence | None, agg.segment_confidence)
+    return TempoSegmentPaceResult(
+        tempo_segment_pace_min_per_mi=agg.segment_pace_min_per_mi,
+        tempo_segment_avg_hr_bpm=agg.segment_avg_hr_bpm,
+        tempo_segment_pace_source=source,
+        tempo_segment_split_count=agg.segment_split_count,
+        tempo_segment_confidence=confidence,
+    )
+
+
 def select_qualifying_tempo_splits(
     splits: list[TempoSplitRow],
     zones: TempoHrZoneBounds,
 ) -> list[QualifyingTempoSplit]:
-    if not splits:
-        return []
+    def classify(avg_hr: float) -> str | None:
+        tier = _classify_split_hr(avg_hr, zones)
+        return tier
 
-    eligible = _eligible_split_indices([s.split_index for s in splits])
-    tiered: list[tuple[QualificationTier, TempoSplitRow]] = []
-
-    for row in splits:
-        if row.split_index not in eligible:
-            continue
-        if row.avg_hr is None or row.pace_min_per_mi is None or row.distance_mi is None:
-            continue
-        if row.distance_mi <= 0 or row.pace_min_per_mi <= 0:
-            continue
-        tier = _classify_split_hr(float(row.avg_hr), zones)
-        if tier is not None:
-            tiered.append((tier, row))
-
-    primary = [
-        QualifyingTempoSplit(
-            split_index=row.split_index,
-            pace_min_per_mi=float(row.pace_min_per_mi),
-            distance_mi=float(row.distance_mi),
-            avg_hr_bpm=float(row.avg_hr),
-            tier="z3",
-        )
-        for tier, row in tiered
-        if tier == "z3"
-    ]
-    if primary:
-        return primary
-
-    return [
-        QualifyingTempoSplit(
-            split_index=row.split_index,
-            pace_min_per_mi=float(row.pace_min_per_mi),
-            distance_mi=float(row.distance_mi),
-            avg_hr_bpm=float(row.avg_hr),
-            tier="quality",
-        )
-        for tier, row in tiered
-        if tier == "quality"
-    ]
+    core = select_qualifying_splits(
+        _split_rows_from_tempo(splits),
+        classify_split_hr=classify,
+        primary_tier=_TEMPO_PRIMARY_TIER,
+        quality_tier=_TEMPO_QUALITY_TIER,
+        min_splits_for_warmup_trim=TEMPO_RUN_MIN_SPLITS_WITH_HR,
+    )
+    return _qualifying_from_core(core)
 
 
 def distance_weighted_pace_min_per_mi(
     qualifying: list[QualifyingTempoSplit],
 ) -> float | None:
-    if not qualifying:
-        return None
-    num = 0.0
-    den = 0.0
-    for split in qualifying:
-        num += split.pace_min_per_mi * split.distance_mi
-        den += split.distance_mi
-    if den <= 0:
-        return None
-    return round(num / den, 4)
+    return _distance_weighted_pace_min_per_mi(_qualifying_to_core(qualifying))
 
 
 def distance_weighted_avg_hr_bpm(
     qualifying: list[QualifyingTempoSplit],
 ) -> float | None:
-    if not qualifying:
-        return None
-    num = 0.0
-    den = 0.0
-    for split in qualifying:
-        num += split.avg_hr_bpm * split.distance_mi
-        den += split.distance_mi
-    if den <= 0:
-        return None
-    return round(num / den, 2)
-
-
-def _qualifying_miles(qualifying: list[QualifyingTempoSplit]) -> float:
-    return sum(split.distance_mi for split in qualifying)
-
-
-def _has_strong_qualifying_volume(qualifying: list[QualifyingTempoSplit]) -> bool:
-    return (
-        len(qualifying) >= MIN_SPLITS_STRONG_EVIDENCE
-        and _qualifying_miles(qualifying) >= MIN_QUALIFYING_MILES_STRONG_EVIDENCE
-    )
-
-
-def _source_and_confidence(
-    qualifying: list[QualifyingTempoSplit],
-) -> tuple[TempoSegmentPaceSource, TempoSegmentConfidence]:
-    has_z3 = any(split.tier == "z3" for split in qualifying)
-    strong = _has_strong_qualifying_volume(qualifying)
-    if has_z3:
-        return (
-            "splits_hr_z3",
-            "high" if strong else "medium",
-        )
-    return (
-        "splits_hr_quality",
-        "medium" if strong else "low",
-    )
+    return _distance_weighted_avg_hr_bpm(_qualifying_to_core(qualifying))
 
 
 def aggregate_qualifying_tempo_splits(
     qualifying: list[QualifyingTempoSplit],
 ) -> TempoSegmentPaceResult:
-    pace = distance_weighted_pace_min_per_mi(qualifying)
-    avg_hr = distance_weighted_avg_hr_bpm(qualifying)
-    if pace is None or avg_hr is None:
-        return TempoSegmentPaceResult(
-            tempo_segment_pace_min_per_mi=None,
-            tempo_segment_avg_hr_bpm=None,
-            tempo_segment_pace_source=None,
-            tempo_segment_split_count=0,
-            tempo_segment_confidence=None,
-        )
-
-    source, confidence = _source_and_confidence(qualifying)
-
-    return TempoSegmentPaceResult(
-        tempo_segment_pace_min_per_mi=pace,
-        tempo_segment_avg_hr_bpm=avg_hr,
-        tempo_segment_pace_source=source,
-        tempo_segment_split_count=len(qualifying),
-        tempo_segment_confidence=confidence,
+    agg = _aggregate_qualifying_splits(
+        _qualifying_to_core(qualifying),
+        _TEMPO_POLICY,
+        min_splits_strong=MIN_SPLITS_STRONG_EVIDENCE,
+        min_miles_strong=MIN_QUALIFYING_MILES_STRONG_EVIDENCE,
     )
+    return _tempo_result_from_aggregate(agg)
 
 
 def compute_run_tempo_segment_pace(
@@ -246,5 +222,11 @@ def combine_weekly_tempo_segment_pace(
     per_run_qualifying: list[list[QualifyingTempoSplit]],
 ) -> TempoSegmentPaceResult:
     """Distance-weighted rollup across all qualifying tempo splits in the week."""
-    combined = [split for run in per_run_qualifying for split in run]
-    return aggregate_qualifying_tempo_splits(combined)
+    core_runs = [_qualifying_to_core(run) for run in per_run_qualifying]
+    agg = combine_weekly_qualifying_splits(
+        core_runs,
+        _TEMPO_POLICY,
+        min_splits_strong=MIN_SPLITS_STRONG_EVIDENCE,
+        min_miles_strong=MIN_QUALIFYING_MILES_STRONG_EVIDENCE,
+    )
+    return _tempo_result_from_aggregate(agg)

--- a/tests/smartcoach_mobile_coach/execution_analytics/test_qualified_segment_core.py
+++ b/tests/smartcoach_mobile_coach/execution_analytics/test_qualified_segment_core.py
@@ -1,0 +1,166 @@
+"""Direct tests for shared HR-qualified segment mechanics."""
+
+from __future__ import annotations
+
+from src.smartcoach_mobile_coach.execution_analytics.qualified_segment import (
+    QualifyingSplit,
+    SourceConfidencePolicy,
+    SplitRow,
+    aggregate_qualifying_splits,
+    combine_weekly_qualifying_splits,
+    distance_weighted_avg_hr_bpm,
+    distance_weighted_pace_min_per_mi,
+    eligible_split_indices,
+    has_strong_qualifying_volume,
+    qualifying_miles,
+    resolve_source_and_confidence,
+    select_qualifying_splits,
+)
+from src.smartcoach_mobile_coach.execution_analytics.thresholds import (
+    MIN_QUALIFYING_MILES_STRONG_EVIDENCE,
+    MIN_SPLITS_STRONG_EVIDENCE,
+    TEMPO_RUN_MIN_SPLITS_WITH_HR,
+)
+
+ZONES_POLICY = SourceConfidencePolicy(
+    primary_tier="z3",
+    primary_source="splits_hr_z3",
+    fallback_source="splits_hr_quality",
+)
+
+Z2_HIGH = 145.0
+Z3_LO = 146.0
+Z3_HI = 160.0
+Z4_LO = 161.0
+
+
+def _classify_tempo_hr(avg_hr: float) -> str | None:
+    if Z3_LO <= avg_hr <= Z3_HI:
+        return "z3"
+    if Z2_HIGH < avg_hr <= Z4_LO:
+        return "quality"
+    return None
+
+
+def _row(
+    idx: int,
+    *,
+    hr: float,
+    pace: float,
+    distance: float = 1.0,
+) -> SplitRow:
+    return SplitRow(
+        split_index=idx,
+        avg_hr=hr,
+        pace_min_per_mi=pace,
+        distance_mi=distance,
+    )
+
+
+def test_eligible_split_indices_trims_warmup_when_enough_splits():
+    assert eligible_split_indices([1, 2, 3, 4, 5], min_splits_for_warmup_trim=3) == {
+        2,
+        3,
+        4,
+    }
+    assert eligible_split_indices([1, 2], min_splits_for_warmup_trim=3) == {1, 2}
+
+
+def test_distance_weighted_pace_and_hr():
+    qualifying = [
+        QualifyingSplit(1, 7.0, 2.0, 150.0, "z3"),
+        QualifyingSplit(2, 6.0, 1.0, 152.0, "z3"),
+    ]
+    assert distance_weighted_pace_min_per_mi(qualifying) == 6.6667
+    assert distance_weighted_avg_hr_bpm(qualifying) == 150.67
+
+
+def test_has_strong_qualifying_volume():
+    weak = [QualifyingSplit(1, 7.0, 0.7, 150.0, "z3")]
+    assert (
+        has_strong_qualifying_volume(
+            weak,
+            min_splits=MIN_SPLITS_STRONG_EVIDENCE,
+            min_miles=MIN_QUALIFYING_MILES_STRONG_EVIDENCE,
+        )
+        is False
+    )
+    strong = [
+        QualifyingSplit(1, 7.0, 1.0, 150.0, "z3"),
+        QualifyingSplit(2, 7.1, 1.0, 151.0, "z3"),
+    ]
+    assert (
+        has_strong_qualifying_volume(
+            strong,
+            min_splits=MIN_SPLITS_STRONG_EVIDENCE,
+            min_miles=MIN_QUALIFYING_MILES_STRONG_EVIDENCE,
+        )
+        is True
+    )
+    assert qualifying_miles(strong) == 2.0
+
+
+def test_resolve_source_and_confidence_z3_vs_quality():
+    z3 = [QualifyingSplit(1, 7.0, 2.0, 150.0, "z3")]
+    assert resolve_source_and_confidence(
+        z3,
+        ZONES_POLICY,
+        min_splits=MIN_SPLITS_STRONG_EVIDENCE,
+        min_miles=MIN_QUALIFYING_MILES_STRONG_EVIDENCE,
+    ) == ("splits_hr_z3", "medium")
+
+    quality = [
+        QualifyingSplit(1, 7.0, 2.0, 161.0, "quality"),
+        QualifyingSplit(2, 7.1, 2.0, 161.0, "quality"),
+    ]
+    assert resolve_source_and_confidence(
+        quality,
+        ZONES_POLICY,
+        min_splits=MIN_SPLITS_STRONG_EVIDENCE,
+        min_miles=MIN_QUALIFYING_MILES_STRONG_EVIDENCE,
+    ) == ("splits_hr_quality", "medium")
+
+
+def test_select_qualifying_splits_matches_tempo_z3_rules():
+    splits = [
+        _row(1, hr=125.0, pace=9.5),
+        _row(2, hr=155.0, pace=7.5),
+        _row(3, hr=157.0, pace=7.3),
+        _row(4, hr=130.0, pace=9.0),
+    ]
+    qualifying = select_qualifying_splits(
+        splits,
+        classify_split_hr=_classify_tempo_hr,
+        primary_tier="z3",
+        quality_tier="quality",
+        min_splits_for_warmup_trim=TEMPO_RUN_MIN_SPLITS_WITH_HR,
+    )
+    assert [q.split_index for q in qualifying] == [2, 3]
+    result = aggregate_qualifying_splits(
+        qualifying,
+        ZONES_POLICY,
+        min_splits_strong=MIN_SPLITS_STRONG_EVIDENCE,
+        min_miles_strong=MIN_QUALIFYING_MILES_STRONG_EVIDENCE,
+    )
+    assert result.segment_pace_source == "splits_hr_z3"
+    assert result.segment_confidence == "high"
+    assert result.segment_pace_min_per_mi == 7.4
+    assert result.segment_avg_hr_bpm == 156.0
+
+
+def test_combine_weekly_qualifying_splits():
+    run_a = [
+        QualifyingSplit(1, 7.0, 2.0, 150.0, "z3"),
+        QualifyingSplit(2, 6.0, 1.0, 151.0, "z3"),
+    ]
+    run_b = [QualifyingSplit(1, 8.0, 1.0, 152.0, "z3")]
+    weekly = combine_weekly_qualifying_splits(
+        [run_a, run_b],
+        ZONES_POLICY,
+        min_splits_strong=MIN_SPLITS_STRONG_EVIDENCE,
+        min_miles_strong=MIN_QUALIFYING_MILES_STRONG_EVIDENCE,
+    )
+    assert weekly.segment_split_count == 3
+    assert weekly.segment_pace_source == "splits_hr_z3"
+    assert weekly.segment_confidence == "high"
+    assert weekly.segment_pace_min_per_mi == 7.0

--- a/tests/smartcoach_mobile_coach/execution_analytics/test_tempo_segment_qualified_segment_parity.py
+++ b/tests/smartcoach_mobile_coach/execution_analytics/test_tempo_segment_qualified_segment_parity.py
@@ -1,0 +1,193 @@
+"""Regression: Tempo wrapper outputs match shared qualified_segment + Tempo policy."""
+
+from __future__ import annotations
+
+from src.smartcoach_mobile_coach.execution_analytics.qualified_segment import (
+    SourceConfidencePolicy,
+    SplitRow,
+    aggregate_qualifying_splits,
+    combine_weekly_qualifying_splits,
+    select_qualifying_splits,
+)
+from src.smartcoach_mobile_coach.execution_analytics.tempo_segment import (
+    TempoHrZoneBounds,
+    TempoSplitRow,
+    _classify_split_hr,
+    aggregate_qualifying_tempo_splits,
+    combine_weekly_tempo_segment_pace,
+    compute_run_tempo_segment_pace,
+    select_qualifying_tempo_splits,
+)
+from src.smartcoach_mobile_coach.execution_analytics.thresholds import (
+    MIN_QUALIFYING_MILES_STRONG_EVIDENCE,
+    MIN_SPLITS_STRONG_EVIDENCE,
+    TEMPO_RUN_MIN_SPLITS_WITH_HR,
+)
+
+ZONES = TempoHrZoneBounds(
+    z2_high=145.0,
+    z3_low=146.0,
+    z3_high=160.0,
+    z4_low=161.0,
+)
+
+TEMPO_POLICY = SourceConfidencePolicy(
+    primary_tier="z3",
+    primary_source="splits_hr_z3",
+    fallback_source="splits_hr_quality",
+)
+
+REGRESSION_SCENARIOS = [
+    {
+        "name": "warmup_middle_z3",
+        "splits": [
+            (1, 125.0, 9.5, 1.0),
+            (2, 155.0, 7.5, 1.0),
+            (3, 157.0, 7.3, 1.0),
+            (4, 130.0, 9.0, 1.0),
+        ],
+        "activity_avg": None,
+        "expected_pace": 7.4,
+        "expected_hr": 156.0,
+        "expected_source": "splits_hr_z3",
+        "expected_confidence": "high",
+        "expected_split_count": 2,
+    },
+    {
+        "name": "quality_fallback_low",
+        "splits": [(1, 161.0, 7.0, 1.0)],
+        "activity_avg": None,
+        "expected_pace": 7.0,
+        "expected_hr": 161.0,
+        "expected_source": "splits_hr_quality",
+        "expected_confidence": "low",
+        "expected_split_count": 1,
+    },
+    {
+        "name": "no_qualifying_activity_avg",
+        "splits": [(1, 120.0, 8.0, 1.0)],
+        "activity_avg": 8.5,
+        "expected_pace": None,
+        "expected_hr": None,
+        "expected_source": "activity_avg",
+        "expected_confidence": None,
+        "expected_split_count": 0,
+    },
+]
+
+
+def _tempo_rows(
+    spec: list[tuple[int, float, float, float]],
+) -> list[TempoSplitRow]:
+    return [
+        TempoSplitRow(
+            split_index=idx,
+            avg_hr=hr,
+            pace_min_per_mi=pace,
+            distance_mi=distance,
+        )
+        for idx, hr, pace, distance in spec
+    ]
+
+
+def _core_rows(
+    spec: list[tuple[int, float, float, float]],
+) -> list[SplitRow]:
+    return [
+        SplitRow(
+            split_index=idx,
+            avg_hr=hr,
+            pace_min_per_mi=pace,
+            distance_mi=distance,
+        )
+        for idx, hr, pace, distance in spec
+    ]
+
+
+def test_tempo_wrapper_matches_core_aggregate_for_regression_scenarios():
+    for scenario in REGRESSION_SCENARIOS:
+        tempo_splits = _tempo_rows(scenario["splits"])
+        tempo_result, tempo_qualifying = compute_run_tempo_segment_pace(
+            tempo_splits,
+            ZONES,
+            activity_avg_pace_min_per_mi=scenario["activity_avg"],
+        )
+
+        if scenario["expected_source"] == "activity_avg":
+            assert tempo_result.tempo_segment_pace_source == "activity_avg"
+            assert tempo_result.tempo_segment_pace_min_per_mi is None
+            continue
+
+        core_qualifying = select_qualifying_splits(
+            _core_rows(scenario["splits"]),
+            classify_split_hr=lambda hr: _classify_split_hr(hr, ZONES),
+            primary_tier="z3",
+            quality_tier="quality",
+            min_splits_for_warmup_trim=TEMPO_RUN_MIN_SPLITS_WITH_HR,
+        )
+        core_result = aggregate_qualifying_splits(
+            core_qualifying,
+            TEMPO_POLICY,
+            min_splits_strong=MIN_SPLITS_STRONG_EVIDENCE,
+            min_miles_strong=MIN_QUALIFYING_MILES_STRONG_EVIDENCE,
+        )
+
+        assert (
+            tempo_result.tempo_segment_pace_min_per_mi
+            == core_result.segment_pace_min_per_mi
+        )
+        assert tempo_result.tempo_segment_avg_hr_bpm == core_result.segment_avg_hr_bpm
+        assert tempo_result.tempo_segment_pace_source == core_result.segment_pace_source
+        assert tempo_result.tempo_segment_confidence == core_result.segment_confidence
+        assert tempo_result.tempo_segment_split_count == core_result.segment_split_count
+
+        assert tempo_result.tempo_segment_pace_min_per_mi == scenario["expected_pace"]
+        assert tempo_result.tempo_segment_avg_hr_bpm == scenario["expected_hr"]
+        assert tempo_result.tempo_segment_pace_source == scenario["expected_source"]
+        assert tempo_result.tempo_segment_confidence == scenario["expected_confidence"]
+        assert (
+            tempo_result.tempo_segment_split_count == scenario["expected_split_count"]
+        )
+        assert len(tempo_qualifying) == scenario["expected_split_count"]
+
+
+def test_select_and_weekly_combine_match_core():
+    splits = _tempo_rows([(1, 150.0, 7.0, 2.0), (2, 151.0, 6.0, 1.0)])
+    tempo_q = select_qualifying_tempo_splits(splits, ZONES)
+    core_q = select_qualifying_splits(
+        _core_rows([(1, 150.0, 7.0, 2.0), (2, 151.0, 6.0, 1.0)]),
+        classify_split_hr=lambda hr: _classify_split_hr(hr, ZONES),
+        primary_tier="z3",
+        quality_tier="quality",
+        min_splits_for_warmup_trim=TEMPO_RUN_MIN_SPLITS_WITH_HR,
+    )
+    assert [(q.split_index, q.pace_min_per_mi, q.tier) for q in tempo_q] == [
+        (q.split_index, q.pace_min_per_mi, q.tier) for q in core_q
+    ]
+
+    run_a = select_qualifying_tempo_splits(
+        _tempo_rows([(1, 150.0, 7.0, 2.0), (2, 151.0, 6.0, 1.0)]), ZONES
+    )
+    run_b = select_qualifying_tempo_splits(_tempo_rows([(1, 152.0, 8.0, 1.0)]), ZONES)
+    tempo_weekly = combine_weekly_tempo_segment_pace([run_a, run_b])
+    core_weekly = combine_weekly_qualifying_splits(
+        [
+            core_q,
+            select_qualifying_splits(
+                _core_rows([(1, 152.0, 8.0, 1.0)]),
+                classify_split_hr=lambda hr: _classify_split_hr(hr, ZONES),
+                primary_tier="z3",
+                quality_tier="quality",
+                min_splits_for_warmup_trim=TEMPO_RUN_MIN_SPLITS_WITH_HR,
+            ),
+        ],
+        TEMPO_POLICY,
+        min_splits_strong=MIN_SPLITS_STRONG_EVIDENCE,
+        min_miles_strong=MIN_QUALIFYING_MILES_STRONG_EVIDENCE,
+    )
+    assert (
+        tempo_weekly.tempo_segment_pace_min_per_mi
+        == core_weekly.segment_pace_min_per_mi
+    )
+    assert tempo_weekly.tempo_segment_confidence == core_weekly.segment_confidence
+    assert tempo_weekly.tempo_segment_pace_source == core_weekly.segment_pace_source


### PR DESCRIPTION
## Summary

Extract reusable HR-qualified segment mechanics from Tempo into `qualified_segment.py`, with `tempo_segment.py` remaining the public Tempo wrapper.

- **Tempo public API preserved** — same types and entry points; producers/combine/weekly-history call sites unchanged.
- **Existing tests pass** — Tempo segment pace, execution analytics combine/producer, and weekly-history Tempo tests (no import-only churn beyond new test modules).
- **Quality-only fallback preserved** — strong volume on quality-tier splits still yields `splits_hr_quality` with **medium** confidence (only primary-tier / Z3 can reach high).
- **New coverage** — direct core unit tests plus wrapper-vs-core parity/regression scenarios.

## Scope (explicitly out)

- No Threshold behavior, columns, or tab
- No DB migrations or schema changes
- No weekly-history API changes
- No mobile changes
- No HR formula, runner_profile zone ownership, Apple Health, or chart design changes

**A1 Threshold work is intentionally deferred until this PR (A0) is reviewed and merged.**

## Test plan

- [x] `pytest tests/smartcoach_mobile_coach/test_tempo_segment_pace.py`
- [x] `pytest tests/smartcoach_mobile_coach/execution_analytics/`
- [x] `pytest tests/smartcoach_mobile_coach/test_execution_analytics_combine.py tests/smartcoach_mobile_coach/test_execution_analytics_producer.py`
- [x] `pytest tests/smartcoach_mobile_coach/test_compute_week_tempo_segment_pace.py`
- [x] `pytest tests/smartcoach_mobile_coach/test_weekly_insight_tempo_pace_progress.py tests/smartcoach_mobile_coach/test_weekly_insight_history_tempo_stored_bands.py`